### PR TITLE
Middleware and routing

### DIFF
--- a/config/chatter.php
+++ b/config/chatter.php
@@ -17,6 +17,7 @@ return [
         'home' => 'forums',
         'discussion' => 'discussion',
         'category' => 'category',
+        'post' => 'post',
         'register' => 'register',
         'login' => 'login'
     ],
@@ -209,6 +210,45 @@ return [
 
     'paginate' => [
         'num_of_results' => 10,
-    ]
+    ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Route Middleware
+    |--------------------------------------------------------------------------
+    |
+    | Configure the middleware applied to specific routes across Chatter. This
+    | gives you full control over middleware throughout your application. You
+    | can allow public access to everything or limit to specific routes.
+    |
+    | Authentication is enforced on create, store, edit and delete routes, no
+    | need to add 'auth' to these routes.
+    |
+    */
+
+    'middleware' => [
+        'global' => ['web'],
+        'home' => [],
+        'discussion' => [
+            'index' => [],
+            'show' => [],
+            'create' => [],
+            'store' => [],
+            'destroy' => [],
+            'edit' => [],
+            'update' => []
+        ],
+        'post' => [
+            'index' => [],
+            'show' => [],
+            'create' => [],
+            'store' => [],
+            'destroy' => [],
+            'edit' => [],
+            'update' => []
+        ]
+        'category' => [
+            'show' => [],
+        ]
+    ]
 ];

--- a/config/chatter.php
+++ b/config/chatter.php
@@ -17,7 +17,7 @@ return [
         'home' => 'forums',
         'discussion' => 'discussion',
         'category' => 'category',
-        'post' => 'post',
+        'post' => 'posts',
         'register' => 'register',
         'login' => 'login'
     ],
@@ -221,8 +221,8 @@ return [
     | gives you full control over middleware throughout your application. You
     | can allow public access to everything or limit to specific routes.
     |
-    | Authentication is enforced on create, store, edit and delete routes, no
-    | need to add 'auth' to these routes.
+    | Authentication is enforced on create, store, edit, update, destroy routes,
+    | no need to add 'auth' to these routes.
     |
     */
 

--- a/src/Routes/web.php
+++ b/src/Routes/web.php
@@ -1,21 +1,193 @@
 <?php
 
-Route::group(['middleware' => 'web'], function () {
+/**
+ * Helpers.
+ */
 
-	$chatter_url = Config::get('chatter.routes.home');
-	Route::get($chatter_url, 'DevDojo\Chatter\Controllers\ChatterController@index');
+// Route helper.
+$route = function ($accessor, $default = '') {
+    return $this->app->config->get('chatter.routes.'.$accessor, $default);
+};
 
-	Route::get($chatter_url.'/login', 'DevDojo\Chatter\Controllers\ChatterController@login');
-	Route::get($chatter_url.'/register', 'DevDojo\Chatter\Controllers\ChatterController@register');
+// Middleware helper.
+$middleware = function ($accessor, $default = []) {
+    return $this->app->config->get('chatter.middleware.'.$accessor, $default);
+};
 
-	$chatter_category_url = Config::get('chatter.routes.home') . '/' . Config::get('chatter.routes.category');
-	Route::get($chatter_category_url . '/{slug}', 'DevDojo\Chatter\Controllers\ChatterController@index');
+// Authentication middleware helper.
+$authMiddleware = function ($accessor) use ($middleware) {
+    return array_unique(
+        array_merge((array) $middleware($accessor), ['auth'])
+    );
+};
 
-	$discussion_url = Config::get('chatter.routes.home') . '/' . Config::get('chatter.routes.discussion');
-	Route::resource($discussion_url, 'DevDojo\Chatter\Controllers\ChatterDiscussionController');
-	Route::get($discussion_url . '/{category}/{slug}', 'DevDojo\Chatter\Controllers\ChatterDiscussionController@show');
+$options = [
+    'prefix' => $route('home'),
+    'middleware' => $middleware('global', 'web')
+];
 
-	$posts_url = Config::get('chatter.routes.home') . '/posts';
-	Route::resource($posts_url, 'DevDojo\Chatter\Controllers\ChatterPostController');
+/**
+ * Chatter routes.
+ */
+Route::group($options, function () use ($route, $middleware, $authMiddleware) {
+    
+    // Home view.
+    Route::get('/', [
+        'uses' => 'DevDojo\Chatter\Controllers\ChatterController@index',
+        'as' => 'chatter.home',
+        'middleware' => $middleware('home')
+    ]);
 
+    // Single category view.
+    Route::get($route('category').'/{slug}', [
+        'uses' => 'DevDojo\Chatter\Controllers\ChatterController@index',
+        'as' => 'chatter.categories.show',
+        'middleware' => $middleware('category.show')
+    ]);
+    
+    /**
+     * User routes.
+     */
+    
+    // Login view.
+    Route::get('login', [
+        'uses' => 'DevDojo\Chatter\Controllers\ChatterController@login',
+        'as' => 'chatter.login'
+    ]);
+    
+    // Register view.
+    Route::get('register', [
+        'uses' => 'DevDojo\Chatter\Controllers\ChatterController@register',
+        'as' => 'chatter.register'
+    ]);
+    
+    /**
+     * Discussion routes.
+     */
+    Route::group(['prefix' => $route('discussion')], function () use ($middleware, $authMiddleware) {
+        
+        // All discussions view.
+        Route::get('/', [
+            'uses' => 'DevDojo\Chatter\Controllers\ChatterDiscussionController@index',
+            'as' => 'chatter.discussions.index',
+            'middleware' => $middleware('discussion.index')
+        ]);
+        
+        // Create discussion view.
+        Route::get('create', [
+            'uses' => 'DevDojo\Chatter\Controllers\ChatterDiscussionController@create',
+            'as' => 'chatter.discussions.create',
+            'middleware' => $authMiddleware('discussion.create')
+        ]);
+        
+        // Store discussion action.
+        Route::post('/', [
+            'uses' => 'DevDojo\Chatter\Controllers\ChatterDiscussionController@store',
+            'as' => 'chatter.discussions.store',
+            'middleware' => $authMiddleware('discussion.store')
+        ]);
+        
+        // Single discussion view.
+        Route::get('{category}/{slug}', [
+            'uses' => 'DevDojo\Chatter\Controllers\ChatterDiscussionController@show',
+            'as' => 'chatter.discussions.showInCategory',
+            'middleware' => $middleware('discussion.show')
+        ]);
+        
+        /**
+         * Specific discussion routes.
+         */
+        Route::group(['prefix' => '{slug}'], function () use ($middleware, $authMiddleware) {
+            
+            // Single discussion view.
+            Route::get('/', [
+                'uses' => 'DevDojo\Chatter\Controllers\ChatterDiscussionController@show',
+                'as' => 'chatter.discussions.show',
+                'middleware' => $middleware('discussion.show')
+            ]);
+            
+            // Edit discussion view.
+            Route::get('edit', [
+                'uses' => 'DevDojo\Chatter\Controllers\ChatterDiscussionController@edit',
+                'as' => 'chatter.discussions.edit',
+                'middleware' => $authMiddleware('discussion.edit')
+            ]);
+            
+            // Update discussion action.
+            Route::put('/', [
+                'uses' => 'DevDojo\Chatter\Controllers\ChatterDiscussionController@update',
+                'as' => 'chatter.discussions.update',
+                'middleware' => $authMiddleware('discussion.update')
+            ]);
+            
+            // Destroy discussion action.
+            Route::delete('/', [
+                'uses' => 'DevDojo\Chatter\Controllers\ChatterDiscussionController@destroy',
+                'as' => 'chatter.discussions.destroy',
+                'middleware' => $authMiddleware('discussion.destroy')
+            ]);
+        });
+    });
+    
+    /**
+     * Post routes.
+     */
+    Route::group(['prefix' => $route('post', 'post')], function () use ($middleware, $authMiddleware) {
+        
+        // All posts view.
+        Route::get('/', [
+            'uses' => 'DevDojo\Chatter\Controllers\ChatterPostController@index',
+            'as' => 'chatter.posts.index',
+            'middleware' => $middleware('post.index')
+        ]);
+        
+        // Create post view.
+        Route::get('create', [
+            'uses' => 'DevDojo\Chatter\Controllers\ChatterPostController@create',
+            'as' => 'chatter.posts.create',
+            'middleware' => $authMiddleware('post.create')
+        ]);
+        
+        // Store post action.
+        Route::post('/', [
+            'uses' => 'DevDojo\Chatter\Controllers\ChatterPostController@store',
+            'as' => 'chatter.posts.store',
+            'middleware' => $authMiddleware('post.store')
+        ]);
+        
+        /**
+         * Specific post routes.
+         */
+        Route::group(['prefix' => '{id}'], function () use ($middleware, $authMiddleware) {
+            
+            // Single post view.
+            Route::get('/', [
+                'uses' => 'DevDojo\Chatter\Controllers\ChatterPostController@show',
+                'as' => 'chatter.posts.show',
+                'middleware' => $middleware('post.show')
+            ]);
+            
+            // Edit post view.
+            Route::get('edit', [
+                'uses' => 'DevDojo\Chatter\Controllers\ChatterPostController@edit',
+                'as' => 'chatter.posts.edit',
+                'middleware' => $authMiddleware('post.edit')
+            ]);
+            
+            // Update post action.
+            Route::put('/', [
+                'uses' => 'DevDojo\Chatter\Controllers\ChatterPostController@update',
+                'as' => 'chatter.posts.update',
+                'middleware' => $authMiddleware('post.update')
+            ]);
+            
+            // Destroy post action.
+            Route::delete('/', [
+                'uses' => 'DevDojo\Chatter\Controllers\ChatterPostController@destroy',
+                'as' => 'chatter.posts.destroy',
+                'middleware' => $authMiddleware('post.destroy')
+            ]);
+        });
+        
+    });
 });

--- a/src/Routes/web.php
+++ b/src/Routes/web.php
@@ -41,7 +41,7 @@ Route::group($options, function () use ($route, $middleware, $authMiddleware) {
     // Single category view.
     Route::get($route('category').'/{slug}', [
         'uses' => 'DevDojo\Chatter\Controllers\ChatterController@index',
-        'as' => 'chatter.categories.show',
+        'as' => 'chatter.category.show',
         'middleware' => $middleware('category.show')
     ]);
     
@@ -69,61 +69,61 @@ Route::group($options, function () use ($route, $middleware, $authMiddleware) {
         // All discussions view.
         Route::get('/', [
             'uses' => 'DevDojo\Chatter\Controllers\ChatterDiscussionController@index',
-            'as' => 'chatter.discussions.index',
+            'as' => 'chatter.discussion.index',
             'middleware' => $middleware('discussion.index')
         ]);
         
         // Create discussion view.
         Route::get('create', [
             'uses' => 'DevDojo\Chatter\Controllers\ChatterDiscussionController@create',
-            'as' => 'chatter.discussions.create',
+            'as' => 'chatter.discussion.create',
             'middleware' => $authMiddleware('discussion.create')
         ]);
         
         // Store discussion action.
         Route::post('/', [
             'uses' => 'DevDojo\Chatter\Controllers\ChatterDiscussionController@store',
-            'as' => 'chatter.discussions.store',
+            'as' => 'chatter.discussion.store',
             'middleware' => $authMiddleware('discussion.store')
         ]);
         
         // Single discussion view.
         Route::get('{category}/{slug}', [
             'uses' => 'DevDojo\Chatter\Controllers\ChatterDiscussionController@show',
-            'as' => 'chatter.discussions.showInCategory',
+            'as' => 'chatter.discussion.showInCategory',
             'middleware' => $middleware('discussion.show')
         ]);
         
         /**
          * Specific discussion routes.
          */
-        Route::group(['prefix' => '{slug}'], function () use ($middleware, $authMiddleware) {
+        Route::group(['prefix' => '{discussion}'], function () use ($middleware, $authMiddleware) {
             
             // Single discussion view.
             Route::get('/', [
                 'uses' => 'DevDojo\Chatter\Controllers\ChatterDiscussionController@show',
-                'as' => 'chatter.discussions.show',
+                'as' => 'chatter.discussion.show',
                 'middleware' => $middleware('discussion.show')
             ]);
             
             // Edit discussion view.
             Route::get('edit', [
                 'uses' => 'DevDojo\Chatter\Controllers\ChatterDiscussionController@edit',
-                'as' => 'chatter.discussions.edit',
+                'as' => 'chatter.discussion.edit',
                 'middleware' => $authMiddleware('discussion.edit')
             ]);
             
             // Update discussion action.
-            Route::put('/', [
+            Route::match(['PUT', 'PATCH'], '/', [
                 'uses' => 'DevDojo\Chatter\Controllers\ChatterDiscussionController@update',
-                'as' => 'chatter.discussions.update',
+                'as' => 'chatter.discussion.update',
                 'middleware' => $authMiddleware('discussion.update')
             ]);
             
             // Destroy discussion action.
             Route::delete('/', [
                 'uses' => 'DevDojo\Chatter\Controllers\ChatterDiscussionController@destroy',
-                'as' => 'chatter.discussions.destroy',
+                'as' => 'chatter.discussion.destroy',
                 'middleware' => $authMiddleware('discussion.destroy')
             ]);
         });
@@ -132,7 +132,7 @@ Route::group($options, function () use ($route, $middleware, $authMiddleware) {
     /**
      * Post routes.
      */
-    Route::group(['prefix' => $route('post', 'post')], function () use ($middleware, $authMiddleware) {
+    Route::group(['prefix' => $route('post', 'posts')], function () use ($middleware, $authMiddleware) {
         
         // All posts view.
         Route::get('/', [
@@ -158,7 +158,7 @@ Route::group($options, function () use ($route, $middleware, $authMiddleware) {
         /**
          * Specific post routes.
          */
-        Route::group(['prefix' => '{id}'], function () use ($middleware, $authMiddleware) {
+        Route::group(['prefix' => '{post}'], function () use ($middleware, $authMiddleware) {
             
             // Single post view.
             Route::get('/', [
@@ -175,7 +175,7 @@ Route::group($options, function () use ($route, $middleware, $authMiddleware) {
             ]);
             
             // Update post action.
-            Route::put('/', [
+            Route::match(['PUT', 'PATCH'], '/', [
                 'uses' => 'DevDojo\Chatter\Controllers\ChatterPostController@update',
                 'as' => 'chatter.posts.update',
                 'middleware' => $authMiddleware('post.update')


### PR DESCRIPTION
Hey,

Love the software, and needed to add some features for my use so thought'd I'd jump on the contributor wagon.

I've...

- Given the user the ability to set middleware for each forum route, a global middleware and enforced auth middleware where appropriate. Also, if the config for middleware is missing, the default values still are applied (backwards compatibility).
- Prefixed all the route names with 'chatter'. Pretty sure named routes haven't been used in the app.
- Added the ability to rename the post route just like the other routes.
- All routes are now explicit rather than implicit with the 'resource' routing. It's a bit more verbose but it makes for better configuration in the long run (my opinion). Route list below....

Before...

![route-list-original](https://cloud.githubusercontent.com/assets/21290589/20094595/1cc888b8-a5f6-11e6-8a3c-d15031aaae5c.png)

After...

![route-list-new](https://cloud.githubusercontent.com/assets/21290589/20094605/26248d80-a5f6-11e6-92d9-c2b00d63a60e.png)


I'm pretty sure all these routes aren't used in the app and can be pruned, but I wanted to tackle one thing at a time. Tested and all looks sweet.

Thoughts? Ideas?