### PR TITLE
Fix "trying to get property of non-object" error when no discussion found

### DIFF
--- a/src/Controllers/ChatterDiscussionController.php
+++ b/src/Controllers/ChatterDiscussionController.php
@@ -177,7 +177,7 @@ class ChatterDiscussionController extends Controller
         }
 
         $discussion = Models::discussion()->where('slug', '=', $slug)->first();
-        if (!$discussion) {
+        if (is_null($discussion)) {
             abort(404);
         }
 

--- a/src/Controllers/ChatterDiscussionController.php
+++ b/src/Controllers/ChatterDiscussionController.php
@@ -177,6 +177,10 @@ class ChatterDiscussionController extends Controller
         }
 
         $discussion = Models::discussion()->where('slug', '=', $slug)->first();
+        if (!$discussion) {
+            abort(404);
+        }
+
         $discussion_category = Models::category()->find($discussion->chatter_category_id);
         if ($category != $discussion_category->slug) {
             return redirect(config('chatter.routes.home').'/'.config('chatter.routes.discussion').'/'.$discussion_category->slug.'/'.$discussion->slug);


### PR DESCRIPTION
The code didnt check wether or not the discussion was actually found which means it would throw an error "trying to get property of non-object" when trying to fetch `chatter_category_id`.

This will make sure that typing a wrong slug for the discussion will throw a 404.