### PR TITLE
fix issue #63 - add check for markdown service provider, add "discussions" to config, pass through title to layouts file

### DIFF
--- a/config/chatter.php
+++ b/config/chatter.php
@@ -28,11 +28,13 @@ return [
     |
     | These are some default titles (words) that will be used throughout your
     | forum. You can change these to whatever you would like :)
+    | 'discussions' is just the plural version of 'discussion'
     |
     */
 
     'titles' => [
         'discussion' => 'Discussion',
+        'discussions' => 'Discussions',
         'category'   => 'Category',
     ],
 

--- a/config/chatter.php
+++ b/config/chatter.php
@@ -33,9 +33,9 @@ return [
     */
 
     'titles' => [
-        'discussion' => 'Discussion',
+        'discussion'  => 'Discussion',
         'discussions' => 'Discussions',
-        'category'   => 'Category',
+        'category'    => 'Category',
     ],
 
    /*

--- a/src/Controllers/ChatterController.php
+++ b/src/Controllers/ChatterController.php
@@ -23,8 +23,10 @@ class ChatterController extends Controller
         $categories = Models::category()->all();
         $chatter_editor = config('chatter.editor');
 
-        // Dynamically register markdown service provider
-        \App::register('GrahamCampbell\Markdown\MarkdownServiceProvider');
+        if ($chatter_editor == 'simplemde') {
+            // Dynamically register markdown service provider
+            \App::register('GrahamCampbell\Markdown\MarkdownServiceProvider');
+        }
 
         return view('chatter::home', compact('discussions', 'categories', 'chatter_editor'));
     }

--- a/src/Controllers/ChatterDiscussionController.php
+++ b/src/Controllers/ChatterDiscussionController.php
@@ -195,8 +195,10 @@ class ChatterDiscussionController extends Controller
 
         $chatter_editor = config('chatter.editor');
 
-        // Dynamically register markdown service provider
-        \App::register('GrahamCampbell\Markdown\MarkdownServiceProvider');
+        if ($chatter_editor == 'simplemde') {
+            // Dynamically register markdown service provider
+            \App::register('GrahamCampbell\Markdown\MarkdownServiceProvider');
+        }
 
         return view('chatter::discussion', compact('discussion', 'posts', 'chatter_editor'));
     }

--- a/src/Views/discussion.blade.php
+++ b/src/Views/discussion.blade.php
@@ -1,4 +1,4 @@
-@extends(Config::get('chatter.master_file_extend'))
+@extends(Config::get('chatter.master_file_extend'), ['title' => $discussion->title])
 
 @section(Config::get('chatter.yields.head'))
 	<link href="/vendor/devdojo/chatter/assets/css/chatter.css" rel="stylesheet">

--- a/src/Views/home.blade.php
+++ b/src/Views/home.blade.php
@@ -55,7 +55,7 @@
 	    		<!-- SIDEBAR -->
 	    		<div class="chatter_sidebar">
 					<button class="btn btn-primary" id="new_discussion_btn"><i class="chatter-new"></i> New {{ Config::get('chatter.titles.discussion') }}</button> 
-					<a href="/{{ Config::get('chatter.routes.home') }}"><i class="chatter-bubble"></i> All {{ Config::get('chatter.titles.discussion') }}</a>
+					<a href="/{{ Config::get('chatter.routes.home') }}"><i class="chatter-bubble"></i> All {{ Config::get('chatter.titles.discussions') }}</a>
 					<ul class="nav nav-pills nav-stacked">
 						<?php $categories = DevDojo\Chatter\Models\Models::category()->all(); ?>
 						@foreach($categories as $category)

--- a/src/Views/home.blade.php
+++ b/src/Views/home.blade.php
@@ -1,4 +1,4 @@
-@extends(Config::get('chatter.master_file_extend'))
+@extends(Config::get('chatter.master_file_extend'), ['title' => Config::get('chatter.titles.discussions')])
 
 @section(Config::get('chatter.yields.head'))
     <link href="/vendor/devdojo/chatter/assets/vendor/spectrum/spectrum.css" rel="stylesheet">


### PR DESCRIPTION
a fresh install preselects tinymce as the default editor and because `GrahamCampbell\Markdown\MarkdownServiceProvider` (used for simplemde) gets registered no matter what it fails.

-> fixes issue #63 

I also added 2 more pull requests, one of them adding the plural config version of 'discussion'. It helps because currently it displays "All Discussion" when it should be "All Discussions".
The second one just passes through a title variable to the layouts file. Could be useful for some as I have been using it.

Edit. sorry, I should have probably created different bases so it would have been 3 pull requests instead of just one. I am fairly new to contributing on here haha if you need me to do that I can close this one and try to send in three separate ones. Or else I will just do it for the future. :-)
