### PR TITLE
add check for markdown service provider

### DIFF
--- a/src/Controllers/ChatterController.php
+++ b/src/Controllers/ChatterController.php
@@ -23,8 +23,10 @@ class ChatterController extends Controller
         $categories = Models::category()->all();
         $chatter_editor = config('chatter.editor');
 
-        // Dynamically register markdown service provider
-        \App::register('GrahamCampbell\Markdown\MarkdownServiceProvider');
+        if ($chatter_editor == 'simplemde') {
+            // Dynamically register markdown service provider
+            \App::register('GrahamCampbell\Markdown\MarkdownServiceProvider');
+        }
 
         return view('chatter::home', compact('discussions', 'categories', 'chatter_editor'));
     }

--- a/src/Controllers/ChatterDiscussionController.php
+++ b/src/Controllers/ChatterDiscussionController.php
@@ -195,8 +195,10 @@ class ChatterDiscussionController extends Controller
 
         $chatter_editor = config('chatter.editor');
 
-        // Dynamically register markdown service provider
-        \App::register('GrahamCampbell\Markdown\MarkdownServiceProvider');
+        if ($chatter_editor == 'simplemde') {
+            // Dynamically register markdown service provider
+            \App::register('GrahamCampbell\Markdown\MarkdownServiceProvider');
+        }
 
         return view('chatter::discussion', compact('discussion', 'posts', 'chatter_editor'));
     }


### PR DESCRIPTION
a fresh install preselects tinymce as the default editor and because GrahamCampbell\Markdown\MarkdownServiceProvider (used for simplemde) gets registered no matter what it fails.

-> fixes issue #63