### PR TITLE
add plural version of "discussion" in config

### DIFF
--- a/config/chatter.php
+++ b/config/chatter.php
@@ -32,8 +32,9 @@ return [
     */
 
     'titles' => [
-        'discussion' => 'Discussion',
-        'category'   => 'Category',
+        'discussion'  => 'Discussion',
+        'discussions' => 'Discussions',
+        'category'    => 'Category',
     ],
 
    /*

--- a/src/Views/home.blade.php
+++ b/src/Views/home.blade.php
@@ -55,7 +55,7 @@
 	    		<!-- SIDEBAR -->
 	    		<div class="chatter_sidebar">
 					<button class="btn btn-primary" id="new_discussion_btn"><i class="chatter-new"></i> New {{ Config::get('chatter.titles.discussion') }}</button> 
-					<a href="/{{ Config::get('chatter.routes.home') }}"><i class="chatter-bubble"></i> All {{ Config::get('chatter.titles.discussion') }}</a>
+					<a href="/{{ Config::get('chatter.routes.home') }}"><i class="chatter-bubble"></i> All {{ Config::get('chatter.titles.discussions') }}</a>
 					<ul class="nav nav-pills nav-stacked">
 						<?php $categories = DevDojo\Chatter\Models\Models::category()->all(); ?>
 						@foreach($categories as $category)


### PR DESCRIPTION
Currently, the home page has displays the options to view "All Discussion". It should be "All Discussions". So I created a new config item that displays the plural version of the "discussion" value.