### PR TITLE
vertically center align update action buttons

### DIFF
--- a/public/assets/css/chatter.css
+++ b/public/assets/css/chatter.css
@@ -512,7 +512,7 @@ body {
 #chatter ul.discussions li.editing .chatter_update_actions {
   background: #fcfcfc;
   display: block;
-  height: 50px;
+  height: 57px;
   padding: 7px;
   top: -5px;
   position: relative;


### PR DESCRIPTION
Currently, there is no margin to the bottom end of the .chatter_update_actions container and it looks like:
<img width="358" alt="screen shot 2017-03-12 at 11 12 17 am" src="https://cloud.githubusercontent.com/assets/6228425/23834536/2ecc7404-0715-11e7-91c5-9d0d17d57c4c.png">

This fix just vertically center aligns the buttons by adding extra height 