### PR TITLE
prevent error - failed to load resource due to tinymce

### DIFF
--- a/public/assets/js/tinymce.js
+++ b/public/assets/js/tinymce.js
@@ -2,7 +2,7 @@ var chatter_tinymce_toolbar = $('#chatter_tinymce_toolbar').val();
 var chatter_tinymce_plugins = $('#chatter_tinymce_plugins').val();
 
 // Initiate the tinymce editor on any textarea with a class of richText
-tinymce.init({ 
+tinymce.init({
 	selector:'textarea.richText',
 	skin: 'chatter',
 	plugins: chatter_tinymce_plugins,
@@ -10,7 +10,7 @@ tinymce.init({
 	menubar: false,
 	statusbar: false,
 	height : "220",
-	content_css : "/css/app.css, /vendor/devdojo/chatter/assets/css/chatter.css",
+	content_css : "/vendor/devdojo/chatter/assets/css/chatter.css",
 	template_popup_height: 380,
 	setup: function (editor) {
         editor.on('init', function(args) {
@@ -35,7 +35,7 @@ tinymce.init({
 });
 
 function initializeNewEditor(id){
-    tinymce.init({ 
+    tinymce.init({
         selector:'#'+id,
         skin: 'chatter',
         plugins: chatter_tinymce_plugins,
@@ -43,7 +43,7 @@ function initializeNewEditor(id){
         menubar: false,
         statusbar: false,
         height : "300",
-        content_css : "/css/app.css, /vendor/devdojo/chatter/assets/css/chatter.css",
+        content_css : "/vendor/devdojo/chatter/assets/css/chatter.css",
         template_popup_height: 380
     });
 }


### PR DESCRIPTION
I understand that content_css is there so that the editable area has the same styling as the surrounding content. But if there is no css/app.css file it will result in a 404 error. For anyone that's wanting to style their editor, I assume that they know what they are doing and they can easily add another resource there.

fixes issue: #77 