### PR TITLE
preset the preheader in email view

### DIFF
--- a/src/Views/email.blade.php
+++ b/src/Views/email.blade.php
@@ -76,7 +76,8 @@
         <td class="container" style="font-family:sans-serif;font-size:14px;vertical-align:top;display:block;max-width:580px;padding:10px;width:580px;Margin:0 auto !important;">
           <div class="content" style="box-sizing:border-box;display:block;Margin:0 auto;max-width:580px;padding:10px;">
             <!-- START CENTERED WHITE CONTAINER -->
-            <span class="preheader" style="color:transparent;display:none;height:0;max-height:0;max-width:0;opacity:0;overflow:hidden;mso-hide:all;visibility:hidden;width:0;">This is preheader text. Some clients will show this text as a preview.</span>
+            <!-- Some clients will show the preheader text as a preview. -->
+            <span class="preheader" style="color:transparent;display:none;height:0;max-height:0;max-width:0;opacity:0;overflow:hidden;mso-hide:all;visibility:hidden;width:0;">Just wanted to let you know that someone has responded to a forum post.</span>
             <table class="main" style="border-collapse:separate;mso-table-lspace:0pt;mso-table-rspace:0pt;background:#fff;border-radius:3px;width:100%;">
               <!-- START MAIN CONTENT AREA -->
               <tr>


### PR DESCRIPTION
Apple Mail will use the preheader and just to make it a little more convenient, set the value to something that is logical.