### PR TITLE
Update 2016_08_02_183143_add_slug_field_for_discussions.php

### DIFF
--- a/database/migrations/2016_08_02_183143_add_slug_field_for_discussions.php
+++ b/database/migrations/2016_08_02_183143_add_slug_field_for_discussions.php
@@ -14,7 +14,7 @@ class AddSlugFieldForDiscussions extends Migration
     public function up()
     {
         Schema::table('chatter_discussion', function (Blueprint $table) {
-            $table->string('slug')->unique();
+            $table->string('slug')->default("slug")->unique();
         });
     }
 


### PR DESCRIPTION
Hi 

When I run tests in sqlite or use sqlite DB, it gives error in running migration. I am attaching a laracast link  for it. That explains it. https://laracasts.com/discuss/channels/general-discussion/migrations-sqlite-general-error-1-cannot-add-a-not-null-column-with-default-value-null
Please update migration. So it can pass tests or will be used with  sqlite DB.

![image](https://cloud.githubusercontent.com/assets/8603325/25464710/7270b54c-2b1b-11e7-93b2-b2ee75cbb5de.png)


TIA