### PR TITLE
Update 2017_01_16_121747_add_markdown_and_lock_to_chatter_posts.php

### DIFF
--- a/database/migrations/2017_01_16_121747_add_markdown_and_lock_to_chatter_posts.php
+++ b/database/migrations/2017_01_16_121747_add_markdown_and_lock_to_chatter_posts.php
@@ -27,8 +27,7 @@ class AddMarkdownAndLockToChatterPosts extends Migration
     public function down()
     {
         Schema::table('chatter_post', function ($table) {
-            $table->dropColumn('markdown');
-            $table->dropColumn('locked');
+            $table->dropColumn(['markdown', 'locked']);
         });
     }
 }


### PR DESCRIPTION
HI
When I use sqlite DB or run tests in sqlite it give error for 
SQLSTATE[HY000]: General error: 1 no such column: markdown

So by assigning an array in down method it starts working , and have no trouble. That's a fix for running tests and sqlite users.
I am attaching screen shot of before and after
![image](https://cloud.githubusercontent.com/assets/8603325/25465130/148ef4d6-2b1e-11e7-9355-eccc4f82d815.png)


TIA