### PR TITLE
5.5 auto discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Quick Note: If this is a new project, make sure to install the default user auth
 
 2. Add the service provider to your `config/app.php` providers array:
 
+   **If you're installing on Laravel 5.5+ skip this step**
+
     ```
     DevDojo\Chatter\ChatterServiceProvider::class,
     ```
@@ -29,7 +31,7 @@ Quick Note: If this is a new project, make sure to install the default user auth
 3. Publish the Vendor Assets files by running:
 
     ```
-    php artisan vendor:publish
+    php artisan vendor:publish --provider="DevDojo\Chatter\ChatterServiceProvider"
     ```
 
 4. Now that we have published a few new files to our application we need to reload them with the following command:

--- a/composer.json
+++ b/composer.json
@@ -32,5 +32,5 @@
                 "DevDojo\\Chatter\\ChatterServiceProvider"
             ]
         }
-    },
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,12 @@
         "classmap": [
             "tests/TestCase.php"
         ]
-    }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "DevDojo\\Chatter\\ChatterServiceProvider"
+            ]
+        }
+    },
 }


### PR DESCRIPTION
Per the [Auto Package Discovery docs](https://laravel.com/docs/5.5/packages#package-discovery) this PR updates the repository to support Laravel 5.5+ Auto Package Discovery, so step 2 of the readme becomes optional for 5.5+ installations.

Also added instructions on the `vendor:publish` command to only publish this packages provider rather than publishing everything in the laravel application.