### PR TITLE
fixes [object HTMLInputElement] editor title bug

### DIFF
--- a/src/Views/home.blade.php
+++ b/src/Views/home.blade.php
@@ -136,7 +136,7 @@
         	<div class="row">
 	        	<div class="col-md-7">
 		        	<!-- TITLE -->
-	                <input type="text" class="form-control" id="title" name="title" placeholder="Title of {{ Config::get('chatter.titles.discussion') }}" v-model="title" value="{{ old('title') }}" >
+	                <input type="text" class="form-control" id="title" name="title" placeholder="@lang('chatter::messages.editor.title')" value="{{ old('title') }}" >
 	            </div>
 
 	            <div class="col-md-4">


### PR DESCRIPTION
Fixes bug #127 and replaces a missing translation for the `placeholder` attribute

Change-Id: I2f30824949b627b5517cf5efa7075ebeff02409f