### PR TITLE
adds Dutch language

### DIFF
--- a/src/Lang/en/email.php
+++ b/src/Lang/en/email.php
@@ -7,7 +7,7 @@ return [
     'view_discussion' => 'View The Discussion',
     'farewell'        => 'Have a great day!',
     'unsuscribe'      => [
-        'message' => 'If you no longer wish to be notified when someone responds to this form post be sure to uncheck the notification setting at the bottom of the page :)',
+        'message' => 'If you no longer wish to be notified when someone responds to this forum post be sure to uncheck the notification setting at the bottom of the page :)',
         'action'  => 'Don\'t like these emails?',
         'link'    => 'Unsubscribe to this Discussion',
     ],

--- a/src/Lang/nl/alert.php
+++ b/src/Lang/nl/alert.php
@@ -1,0 +1,31 @@
+<?php
+
+return [
+    'success' => [
+        'title'  => 'Goed zo!',
+        'reason' => [
+            'submitted_to_post'       => 'Reactie succesvol geplaatst in de discussie.',
+            'updated_post'            => 'De reactie is succesvol aangepast.',
+            'destroy_post'            => 'De discussie en reacties zijn succesvol verwijderd.',
+            'destroy_from_discussion' => 'De reactie is succesvol verwijderd van de discussie.',
+            'created_discussion'      => 'De discussie is succesvol aangemaakt.',
+        ],
+    ],
+    'info' => [
+        'title' => 'Let op!',
+    ],
+    'warning' => [
+        'title' => 'Oeps!',
+    ],
+    'danger'  => [
+        'title'  => 'Oh nee!',
+        'reason' => [
+            'errors'            => 'Los de volgende problemen alsjeblieft op:',
+            'prevent_spam'      => 'Om spam te voorkomen, wacht alsjeblieft :minutes tussen het plaatsen van nieuwe reacties.',
+            'trouble'           => 'Helaas, er is een probleem opgetreden tijdens het plaatsen van je reactie.',
+            'update_post'       => 'Helaas, je kan deze reactie niet wijzigen.',
+            'destroy_post'      => 'Helaas, je kan deze reactie niet verwijderen.',
+            'create_discussion' => 'Helaas, er is een probleem opgetreden tijdens het plaatsen van je discussie :(',
+        ],
+    ],
+];

--- a/src/Lang/nl/email.php
+++ b/src/Lang/nl/email.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    'preheader'       => 'We laten je even weten dat iemand gereageerd heeft op een forum discussie.',
+    'greeting'        => 'Hallo,',
+    'body'            => 'We laten je even weten dat iemand gereageerd heeft op een forum discussie op',
+    'view_discussion' => 'Bekijk de discussie',
+    'farewell'        => 'Nog een fijne dag gewenst!',
+    'unsuscribe'      => [
+        'message' => 'Als je geen notificaties meer wilt ontvangen voor deze discussie, wijzig dan je aanmelding onderaan deze pagina :)',
+        'action'  => 'Genoeg van deze e-mails?',
+        'link'    => 'Afmelden voor deze discussie',
+    ],
+];

--- a/src/Lang/nl/messages.php
+++ b/src/Lang/nl/messages.php
@@ -1,0 +1,44 @@
+<?php
+
+return [
+    'words' => [
+        'cancel'  => 'Annuleer',
+        'delete'  => 'Verwijder',
+        'edit'    => 'Wijzig',
+        'yes'     => 'Ja',
+        'no'      => 'Nee',
+        'minutes' => '1 minuut| :count minuten',
+    ],
+
+    'discussion' => [
+        'new'          => 'Nieuwe discussie',
+        'all'          => 'Toon alle discussies',
+        'create'       => 'Creëer een discussie',
+        'posted_by'    => 'Geplaatst door',
+        'head_details' => 'Geplaatst in',
+
+    ],
+    'response' => [
+        'confirm'     => 'Weet je zeker dat je deze reactie wilt verwijderen?',
+        'yes_confirm' => 'Ja, verwijder het',
+        'no_confirm'  => 'Nee, bedankt',
+        'submit'      => 'Plaats reactie',
+        'update'      => 'Wijzig reactie',
+    ],
+
+    'editor' => [
+        'title'               => 'Titel van je discussie',
+        'select'              => 'Kies een categorie',
+        'tinymce_placeholder' => 'Typ je bericht hier',
+        'select_color_text'   => 'Kies een kleur voor deze discussie (optioneel)',
+    ],
+
+    'email' => [
+        'notify' => 'Stuur mij notificaties van antwoorden',
+    ],
+
+    'auth' => 'Je moet <a href="/:home/login">inloggen</a>
+                of <a href="/:home/register">registreren</a>
+                om een reactie te plaatsen.',
+
+];


### PR DESCRIPTION
Adds informal Dutch translations.

- Informal in the sense of "je" instead of "u" and still playful messages
- Discussions are translated as "discussie" as opposed to "topic"
- Responses are translated as "reacties" as opposed to "post"
- All capitalization mid sentences has been removed, this is not common in Dutch (i.e. "View The Discussion" becomes "Bekijk de discussie")
- I removed the 'blamey' part in the tampering alerts and just replaced with the technical "You can not edit|delete this post" (I looked at the code and it only happens when the user IDs don't match)

Also fixed a typo in the English email translation file.

Change-Id: If998471e04a59dc901fea4d7f98df235bfa721e3