### PR TITLE
Deletes the author validation on ChatterPostController's method 'destroy'

### DIFF
--- a/src/Controllers/ChatterPostController.php
+++ b/src/Controllers/ChatterPostController.php
@@ -203,14 +203,7 @@ class ChatterPostController extends Controller
     public function destroy($id, Request $request)
     {
         $post = Models::post()->with('discussion')->findOrFail($id);
-
-        if ($request->user()->id !== (int) $post->user_id) {
-            return redirect('/'.config('chatter.routes.home'))->with([
-                'chatter_alert_type' => 'danger',
-                'chatter_alert'      => trans('chatter::alert.danger.reason.destroy_post'),
-            ]);
-        }
-
+        
         if ($post->discussion->posts()->oldest()->first()->id === $post->id) {
             if(config('chatter.soft_deletes')) {
                 $post->discussion->posts()->delete();


### PR DESCRIPTION
I deleted this validation from the method to delegate it to a Middleware (which can be provided by Chatter or not) in case you need it and to be able to add custom validations. In my case, I want to validate the user's role and not just the post's author.
I moved the validation to IsPostsAuthor Middleware, you can see it here: https://gist.github.com/gercgl/4f77f5fdc64e96b0f809a8adbfcab29a.

I'll wait for your feedback.