### PR TITLE
Fix broken post/comment editing

### DIFF
--- a/public/assets/js/chatter.js
+++ b/public/assets/js/chatter.js
@@ -25,48 +25,49 @@ $('document').ready(function(){
         // $('#textbox1').val($(this).is(':checked'));        
     });
 
-});
+    // Enable a function $.form to submit a dynamic form
+    jQuery(function($) {
+        $.extend({
+            form: function(url, data, method) {
+                if (method == null) method = 'POST';
+                if (data == null) data = {};
 
-// Enable a function $.form to submit a dynamic form
-jQuery(function($) { $.extend({
-    form: function(url, data, method) {
-        if (method == null) method = 'POST';
-        if (data == null) data = {};
+                var form = $('<form>').attr({
+                    method: method,
+                    action: url
+                }).css({
+                    display: 'none'
+                });
+    
+                var addData = function(name, data) {
+                    if ($.isArray(data)) {
+                        for (var i = 0; i < data.length; i++) {
+                            var value = data[i];
+                            addData(name + '[]', value);
+                        }
+                    } else if (typeof data === 'object') {
+                        for (var key in data) {
+                            if (data.hasOwnProperty(key)) {
+                                addData(name + '[' + key + ']', data[key]);
+                            }
+                        }
+                    } else if (data != null) {
+                        form.append($('<input>').attr({
+                            type: 'hidden',
+                            name: String(name),
+                            value: String(data)
+                        }));
+                    }
+                };
 
-        var form = $('<form>').attr({
-            method: method,
-            action: url
-         }).css({
-            display: 'none'
-         });
-
-        var addData = function(name, data) {
-            if ($.isArray(data)) {
-                for (var i = 0; i < data.length; i++) {
-                    var value = data[i];
-                    addData(name + '[]', value);
-                }
-            } else if (typeof data === 'object') {
                 for (var key in data) {
                     if (data.hasOwnProperty(key)) {
-                        addData(name + '[' + key + ']', data[key]);
+                        addData(key, data[key]);
                     }
                 }
-            } else if (data != null) {
-                form.append($('<input>').attr({
-                  type: 'hidden',
-                  name: String(name),
-                  value: String(data)
-                }));
-            }
-        };
 
-        for (var key in data) {
-            if (data.hasOwnProperty(key)) {
-                addData(key, data[key]);
+                return form.appendTo('body');
             }
-        }
-
-        return form.appendTo('body');
-    }
-}); });
+        });
+    });
+});


### PR DESCRIPTION
Addresses #129 

**Problem**: Editing posts or comments results in an error: `$.form is not defined`. It appears that the addition of `$.form` that Chatter performs in `chatter.js` is not being processed in time to be used.

**Fix**: In `chatter.js`, I moved the declaration of `$.form` into the `$('document').ready(function(){` block so that it would be loaded when the DOM loads, ensuring that jQuery is fully loaded and ready to go before this definition occurs.

I am not sure how this lines up with future goals for this package, but it can be considered a hotfix for now, if the eventual goal is to refactor away from the `$.form` method.