### PR TITLE
Fix bug in ChatterController, posts and discussions ordering

### DIFF
--- a/src/Controllers/ChatterController.php
+++ b/src/Controllers/ChatterController.php
@@ -13,7 +13,7 @@ class ChatterController extends Controller
     {
         $pagination_results = config('chatter.paginate.num_of_results');
         
-        $discussions = Models::discussion()->with('user')->with('post')->with('postsCount')->with('category')->orderBy(config('chatter.order_by.discussions.order'), config('chatter.order_by.discussions.by'));
+        $discussions = Models::discussion()->with('user')->with('post')->with('postsCount')->with('category')->orderBy(config('chatter.order_by.posts.order'), config('chatter.order_by.discussions.by'));
         if (isset($slug)) {
             $category = Models::category()->where('slug', '=', $slug)->first();
             


### PR DESCRIPTION
A discussion should be ordered by posts and discussions instead of discussions and discussions

**Issue:** Currently order by posts in config has no effect because the order by clause uses chatter.order_by.discussions.by and chatter.order_by.discussions.by

**Fix:** update order by clause to use chatter.order_by.posts.order and chatter.order_by.discussions.by