### PR TITLE
Refactor in post delete and update authorization logic

### DIFF
--- a/src/Controllers/ChatterPostController.php
+++ b/src/Controllers/ChatterPostController.php
@@ -8,6 +8,7 @@ use DevDojo\Chatter\Events\ChatterAfterNewResponse;
 use DevDojo\Chatter\Events\ChatterBeforeNewResponse;
 use DevDojo\Chatter\Mail\ChatterDiscussionUpdated;
 use DevDojo\Chatter\Models\Models;
+use DevDojo\Chatter\Requests\ChatterDeletePostRequest;
 use Event;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as Controller;
@@ -210,17 +211,10 @@ class ChatterPostController extends Controller
      *
      * @return \Illuminate\Routing\Redirect
      */
-    public function destroy($id, Request $request)
+    public function destroy($id, ChatterDeletePostRequest $request)
     {
         $post = Models::post()->with('discussion')->findOrFail($id);
-
-        if ($request->user()->id !== (int) $post->user_id) {
-            return redirect('/'.config('chatter.routes.home'))->with([
-                'chatter_alert_type' => 'danger',
-                'chatter_alert'      => trans('chatter::alert.danger.reason.destroy_post'),
-            ]);
-        }
-
+        
         if ($post->discussion->posts()->oldest()->first()->id === $post->id) {
             if(config('chatter.soft_deletes')) {
                 $post->discussion->posts()->delete();

--- a/src/Exceptions/ChatterUserIsNotAllowedToDeletePostException.php
+++ b/src/Exceptions/ChatterUserIsNotAllowedToDeletePostException.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DevDojo\Chatter\Exceptions;
+
+use Exception;
+
+class ChatterUserIsNotAllowedToDeletePostException extends Exception
+{
+    
+    /**
+     * Report the exception.
+     *
+     * @return void
+     */
+    public function report()
+    {
+        //
+    }
+    
+    /**
+     * Render the exception into an HTTP response.
+     *
+     * @param  \Illuminate\Http\Request
+     * @return \Illuminate\Http\Response
+     */
+    public function render($request)
+    {
+        return redirect('/' . config('chatter.routes.home'))->with([
+            'chatter_alert_type' => 'danger',
+            'chatter_alert'      => trans('chatter::alert.danger.reason.destroy_post'),
+        ]);
+    }
+    
+}

--- a/src/Exceptions/PostDeleteNotAllowedException.php
+++ b/src/Exceptions/PostDeleteNotAllowedException.php
@@ -4,7 +4,7 @@ namespace DevDojo\Chatter\Exceptions;
 
 use Exception;
 
-class ChatterUserIsNotAllowedToDeletePostException extends Exception
+class PostDeleteNotAllowedException extends Exception
 {
     
     /**

--- a/src/Exceptions/PostUpdateNotAllowedException.php
+++ b/src/Exceptions/PostUpdateNotAllowedException.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DevDojo\Chatter\Exceptions;
+
+use Exception;
+
+class PostUpdateNotAllowedException extends Exception
+{
+    
+    /**
+     * Report the exception.
+     *
+     * @return void
+     */
+    public function report()
+    {
+        //
+    }
+    
+    /**
+     * Render the exception into an HTTP response.
+     *
+     * @param  \Illuminate\Http\Request
+     * @return \Illuminate\Http\Response
+     */
+    public function render($request)
+    {
+        return redirect('/' . config('chatter.routes.home'))->with([
+            'chatter_alert_type' => 'danger',
+            'chatter_alert'      => trans('chatter::alert.danger.reason.update_post'),
+        ]);
+    }
+    
+}

--- a/src/Requests/ChatterDeletePostRequest.php
+++ b/src/Requests/ChatterDeletePostRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace DevDojo\Chatter\Requests;
+
+use DevDojo\Chatter\Exceptions\ChatterUserIsNotAllowedToDeletePostException;
+use DevDojo\Chatter\Models\Models;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Auth\Access\AuthorizationException;
+
+class ChatterDeletePostRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        $parameters = $this->route()->parameters;
+
+        $post = Models::post()->with('discussion')->findOrFail($parameters['post']);
+
+        return $this->user()->id === (int) $post->user_id;
+    }
+    
+    /**
+     * Handle a failed authorization attempt.
+     *
+     * @return void
+     *
+     * @throws ChatterUserIsNotAllowedToDeletePostException
+     */
+    protected function failedAuthorization()
+    {
+        throw new ChatterUserIsNotAllowedToDeletePostException();
+    }
+    
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/src/Requests/ChatterDeletePostRequest.php
+++ b/src/Requests/ChatterDeletePostRequest.php
@@ -2,7 +2,7 @@
 
 namespace DevDojo\Chatter\Requests;
 
-use DevDojo\Chatter\Exceptions\ChatterUserIsNotAllowedToDeletePostException;
+use DevDojo\Chatter\Exceptions\PostDeleteNotAllowedException;
 use DevDojo\Chatter\Models\Models;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -28,11 +28,11 @@ class ChatterDeletePostRequest extends FormRequest
      *
      * @return void
      *
-     * @throws ChatterUserIsNotAllowedToDeletePostException
+     * @throws PostDeleteNotAllowedException
      */
     protected function failedAuthorization()
     {
-        throw new ChatterUserIsNotAllowedToDeletePostException();
+        throw new PostDeleteNotAllowedException();
     }
     
     /**

--- a/src/Requests/ChatterUpdatePostRequest.php
+++ b/src/Requests/ChatterUpdatePostRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace DevDojo\Chatter\Requests;
+
+use DevDojo\Chatter\Exceptions\PostUpdateNotAllowedException;
+use DevDojo\Chatter\Models\Models;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Auth\Access\AuthorizationException;
+
+class ChatterUpdatePostRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        $parameters = $this->route()->parameters;
+
+        $post = Models::post()->with('discussion')->findOrFail($parameters['post']);
+
+        return (! is_null($this->user())) && $this->user()->id === (int) $post->user_id;
+        
+    }
+    
+    /**
+     * Handle a failed authorization attempt.
+     *
+     * @return void
+     *
+     * @throws ChatterUserIsNotAllowedToDeletePostException
+     */
+    protected function failedAuthorization()
+    {
+        throw new PostUpdateNotAllowedException();
+    }
+    
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+}


### PR DESCRIPTION
I extracted the post delete and update authorization logic to a [FormRequest](https://laravel.com/docs/5.6/validation#form-request-validation) subclass.
In case that you need, it allows you to write your own authorization logic in a custom FormRequest without you have to modify ChatterPostController class.

Wait for your feedback