### PR TITLE
Prevent escaping of login and register links

### DIFF
--- a/src/Views/discussion.blade.php
+++ b/src/Views/discussion.blade.php
@@ -215,7 +215,7 @@
 
 					<div id="login_or_register">
 						<p>
-                            @lang('chatter::messages.auth', ['home' => Config::get('chatter.routes.home')])
+							{!! __('chatter::messages.auth', ['home' => Config::get('chatter.routes.home')]) !!}
                         </p>
 					</div>
 


### PR DESCRIPTION
The @lang blade directive automatically escapes HTML. Since this message includes links, switching to the __ () helper allows us to display them as expected.

#224 