### PR TITLE
Update installation instructions to reflect Laravel 5.6 view change

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ Quick Note: If this is a new project, make sure to install the default user auth
     @yield('js')
     ```
 
+    If you're using Laravel 5.6+ remove defer from the app ```<script>``` tag in ```<head>```:
+    ```
+    <script src="{{ asset('js/app.js') }}"></script>
+    ```
+    Optionally, you can move the script tag to just before ```</body>``` for a similar effect.
+
 Now, visit your site.com/forums and you should see your new forum in front of you!
 
 ### Upgrading


### PR DESCRIPTION
In Laravel 5.6 they moved the location of the app.js script tag from just before </body> to the <head> section adding a defer attribute. In some browsers, jquery has an issue with defer: https://github.com/jquery/jquery/issues/3271

Since this causes a pretty significant issue in this project, the shortest distance seems to be to add a note in the setup instructions, at least in the short term.  

#211 