### PR TITLE
replace Event::fire() with Event::dispatch() for L5.8

### DIFF
--- a/src/Controllers/ChatterDiscussionController.php
+++ b/src/Controllers/ChatterDiscussionController.php
@@ -77,7 +77,7 @@ class ChatterDiscussionController extends Controller
 		]);
         
 
-        Event::fire(new ChatterBeforeNewDiscussion($request, $validator));
+        Event::dispatch(new ChatterBeforeNewDiscussion($request, $validator));
         if (function_exists('chatter_before_new_discussion')) {
             chatter_before_new_discussion($request, $validator);
         }
@@ -149,7 +149,7 @@ class ChatterDiscussionController extends Controller
         $post = Models::post()->create($new_post);
 
         if ($post->id) {
-            Event::fire(new ChatterAfterNewDiscussion($request, $discussion, $post));
+            Event::dispatch(new ChatterAfterNewDiscussion($request, $discussion, $post));
             if (function_exists('chatter_after_new_discussion')) {
                 chatter_after_new_discussion($request);
             }

--- a/src/Controllers/ChatterPostController.php
+++ b/src/Controllers/ChatterPostController.php
@@ -56,7 +56,7 @@ class ChatterPostController extends Controller
 			'body.min' => trans('chatter::alert.danger.reason.content_min'),
 		]);
 
-        Event::fire(new ChatterBeforeNewResponse($request, $validator));
+        Event::dispatch(new ChatterBeforeNewResponse($request, $validator));
         if (function_exists('chatter_before_new_response')) {
             chatter_before_new_response($request, $validator);
         }
@@ -98,7 +98,7 @@ class ChatterPostController extends Controller
             $discussion->last_reply_at = $discussion->freshTimestamp();
             $discussion->save();
             
-            Event::fire(new ChatterAfterNewResponse($request, $new_post));
+            Event::dispatch(new ChatterAfterNewResponse($request, $new_post));
             if (function_exists('chatter_after_new_response')) {
                 chatter_after_new_response($request);
             }


### PR DESCRIPTION
Can't create a new discussion when using Laravel 5.8: 

`Symfony\Component\Debug\Exception\FatalThrowableError Call to undefined method Illuminate\Events\Dispatcher::fire()`.

`Illuminate\Events\Dispatcher::fire()` changed to `dispatch` in Laravel 5.8

