### PR TITLE
Fix #199

### DIFF
--- a/src/Controllers/ChatterDiscussionController.php
+++ b/src/Controllers/ChatterDiscussionController.php
@@ -102,8 +102,11 @@ class ChatterDiscussionController extends Controller
             }
         }
 
-        // *** Let's gaurantee that we always have a generic slug *** //
-        $slug = str_slug($request->title, '-');
+        do {
+            $length = Models::discussion()->count();
+            $length = $length >= 10 ? (int)log10($length) : 0;
+            $slug = str_random(20 + $length);
+        } while (Models::discussion()->where('slug', $slug)->exists());
 
         $discussion_exists = Models::discussion()->where('slug', '=', $slug)->withTrashed()->first();
         $incrementer = 1;


### PR DESCRIPTION
According to [this discussion](https://laracasts.com/discuss/channels/laravel/what-are-the-languages-supported-in-slug-str-slug-function) in Laracasts, the `str_slug` is only language supported for few three languages (`en`, `de`, and `bg`).
That is, if the language of discussion title is not supported, one will get some unexpected error (such as #199).
From here I replace `str_slug` with `str_random` to solve the problem. Also I check existence so as to avoid slug conflict.